### PR TITLE
ルーティングの修正

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -16,9 +16,15 @@ func main() {
 	defer db.DB.Close()
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/", handler.HelloHandler)
-	mux.HandleFunc("/address", handler.AddressHandler)
 	mux.HandleFunc("/address/access_logs", handler.AccessLogsHandler)
+	mux.HandleFunc("/address", handler.AddressHandler)
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		handler.HelloHandler(w, r)
+	})
 
 	fmt.Println("Server is running on :8080...")
 	if err := http.ListenAndServe(":8080", mux); err != nil {

--- a/internal/handler/address.go
+++ b/internal/handler/address.go
@@ -1,4 +1,4 @@
-package handler
+package handler 
 
 import (
 	"encoding/json"
@@ -29,14 +29,14 @@ func isValidPostalCode(postalCode string) bool {
 func AddressHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
-		return
+		return 
 	}
 
 	// 郵便番号のバリテーション
 	postalCode, err := validatePostalCode(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
+		return 
 	}
 
 	// DBにアクセスログの追加
@@ -49,20 +49,20 @@ func AddressHandler(w http.ResponseWriter, r *http.Request) {
 	locations, err := geoapi.FetchLocations(postalCode)
 	if err != nil {
 		http.Error(w, "Server Error", http.StatusInternalServerError)
-		return
+		return 
 	}
 
 	addressResponse := model.AddressResponse{
-		PostalCode:        postalCode,
-		HitCount:          model.GetHitCount(locations),
-		Address:           model.GetCommonAddress(locations),
+		PostalCode: postalCode,
+		HitCount: model.GetHitCount(locations),
+		Address: model.GetCommonAddress(locations),
 		FromTokyoDistance: model.GetFromTokyoStation(locations),
 	}
 
 	jsonAddressResponse, err := json.Marshal(addressResponse)
 	if err != nil {
 		http.Error(w, "Server Error", http.StatusInternalServerError)
-		return
+    return 
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(jsonAddressResponse)


### PR DESCRIPTION
GOのServerMuxはもっとも長く一致するパスを優先してルーティングするため、ハンドラの並び替え、not foundの作成を実施
